### PR TITLE
Add ITSAppUsesNonExemptEncryption to Info.plist

### DIFF
--- a/GamebookEngine/Info.plist
+++ b/GamebookEngine/Info.plist
@@ -69,6 +69,8 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Fixes #21 

Signals to Apple that the app does not use non-exempt encryption 

https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption